### PR TITLE
Specify python2.7 interpreter. chmod +x *.py

### DIFF
--- a/check_mi.py
+++ b/check_mi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 import warnings
 from Queue import Empty

--- a/test_damage.py
+++ b/test_damage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
 # This script works in Linux, not tested in Windows


### PR DESCRIPTION
Because the readme specifies this is for python2.7 the interpeter should also specify this, so now it does. Also chmod +x so we can `./check_mi.py`