### PR TITLE
Fix #5 by adding 'xerror' and 'stderr' psuedo err_detect options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 *check-mi* is a Python 3 script (tested with Python 3.8) that automatically checks the integrity of media files (pictures, video, audio).
 You can check the integrity of a single file, or set of files in a folder and subfolders recursively, finally you can optionally output the list of bad files with their path and details in CSV format. 
 
-The tool tests file integrity using common libraries (Pillow, ImageMagik, FFmpeg) and checking when they are effectively able to decode the media files.
+The tool tests file integrity using common libraries (Pillow, ImageMagick, FFmpeg) and checking when they are effectively able to decode the media files.
 Warning, **image, audio and video formats are very resilient to defects and damages** for this reason the tool cannot detect all the damaged files.
 
 *check-mi* is able, with 100% confidence, to spot files that have broken header/metadata, truncated image files (with *strict_level* >0), and device i/o errors.
@@ -117,7 +117,7 @@ PyPDF2==1.26.0
 Wand==0.4.5
 ```
 You can also use the standard Pillow-PIL module, but it is far slower than Pillow-SIMD.
-Now the implementation wotks with PIL-SIMD all versions ( > < = to 6.2.2 )
+Now the implementation works with PIL-SIMD all versions ( > < = to 6.2.2 )
 
 In case you have only *libav* and not *ffmpeg* library/binaries in your Linux OS, you can fix this by creating a symbolic link *ffmpeg -> full/path/to/avconv* somewhere in your system search path.
 

--- a/check_mi.py
+++ b/check_mi.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import warnings
 from queue import Empty
-from multiprocessing import Pool, Queue, Process
+from multiprocessing import Queue, Process
 
 __author__ = "Fabiano Tarlao"
 __copyright__ = "Copyright 2018, Fabiano Tarlao"
@@ -15,6 +14,7 @@ __status__ = "Beta"
 import sys
 import os
 import time
+import textwrap
 import PIL
 from PIL import Image as ImageP
 from wand.image import Image as ImageW
@@ -49,8 +49,6 @@ MEDIA_EXTENSIONS = []
 
 CONFIG = None
 
-import textwrap as _textwrap
-
 
 class MultilineFormatter(argparse.HelpFormatter):
     def _fill_text(self, text, width, indent):
@@ -58,7 +56,7 @@ class MultilineFormatter(argparse.HelpFormatter):
         paragraphs = text.split('|n ')
         multiline_text = ''
         for paragraph in paragraphs:
-            formatted_paragraph = _textwrap.fill(paragraph, width, initial_indent=indent,
+            formatted_paragraph = textwrap.fill(paragraph, width, initial_indent=indent,
                                                  subsequent_indent=indent) + '\n\n'
             multiline_text = multiline_text + formatted_paragraph
         return multiline_text

--- a/check_mi.py
+++ b/check_mi.py
@@ -382,7 +382,6 @@ def main():
     # manage folder (searches media files into)
 
     # initializations
-    count = 0
     count_bad = 0
     total_file_size = 0
     bad_files_info = [("file_name", "error_message", "file_size[bytes]")]
@@ -408,10 +407,7 @@ def main():
 
     # consume the outcome
     try:
-        for j in range(pre_count):
-
-            count += 1
-
+        for count in range(1, pre_count + 1):
             is_success = out_queue.get(block=True, timeout=CONFIG.timeout)
             file_size = is_success[1][2]
             if file_size != 'NA':

--- a/check_mi.py
+++ b/check_mi.py
@@ -370,7 +370,7 @@ def main():
 
     if os.path.isfile(check_path):
         # manage single file check
-        is_success = check_file(check_path, CONFIG.error_detect)
+        is_success = check_file(check_path, CONFIG.error_detect, strict_level=CONFIG.strict_level)
         if not is_success[0]:
             check_outcome_detail = is_success[1]
             log_check_outcome(check_outcome_detail)

--- a/check_mi.py
+++ b/check_mi.py
@@ -233,16 +233,14 @@ def is_target_file(filename):
 
 
 def ffmpeg_check(filename, error_detect='default', threads=0):
-    if error_detect == 'default':
-        stream = ffmpeg.input(filename)
-    else:
+    ffargs = {'threads': threads}
+    if error_detect != 'default':
         if error_detect == 'strict':
-            custom = '+crccheck+bitstream+buffer+explode'
-        else:
-            custom = error_detect
-        stream = ffmpeg.input(filename, **{'err_detect': custom, 'threads': threads})
+            error_detect = '+crccheck+bitstream+buffer+explode'
+        if error_detect:
+            ffargs.update({'err_detect': error_detect})
 
-    stream = stream.output('pipe:', format="null")
+    stream = ffmpeg.input(filename, **ffargs).output('pipe:', format="null")
     try:
         stream.run(capture_stdout=True, capture_stderr=True, input='')
     except ffmpeg.Error as e:

--- a/check_mi.py
+++ b/check_mi.py
@@ -104,7 +104,7 @@ def arg_parser():
                              'shortcut for +crccheck+bitstream+buffer+explode',
                         dest='error_detect', default='default')
     parser.add_argument('-l', '--strict_level', metavar='L', type=int,
-                        help='uses different apporach for checking images depending on %(metavar)s integer value. '
+                        help='uses different approach for checking images depending on %(metavar)s integer value. '
                              'Accepted values 0,1 (default),2: 0 ImageMagick idenitfy, 1 Pillow library+ImageMagick, '
                              '2 applies both 0+1 checks',
                         dest='strict_level', default=1)
@@ -161,7 +161,7 @@ def pil_check(filename):
 
 
 def magick_check(filename, flip=True):
-    # very useful for xcf, psd and aslo supports pdf
+    # very useful for xcf, psd and also supports pdf
     img = ImageW(filename=filename)
     if flip:
         temp = img.flip

--- a/check_mi.py
+++ b/check_mi.py
@@ -177,7 +177,7 @@ def magick_identify_check(filename):
     out, err = proc.communicate()
     exitcode = proc.returncode
     if exitcode != 0:
-        raise Exception('Identify error:' + str(exitcode))
+        raise Exception(f'Identify error: {exitcode}: {err.decode("utf8").strip()}')
     return out
 
 

--- a/check_mi.py
+++ b/check_mi.py
@@ -245,7 +245,7 @@ def ffmpeg_check(filename, error_detect='default', threads=0):
         stream = ffmpeg.input(filename, **{'err_detect': custom, 'threads': threads})
 
     stream = stream.output('pipe:', format="null")
-    stream.run(capture_stdout=True, capture_stderr=True)
+    stream.run(capture_stdout=True, capture_stderr=True, input='')
 
 
 def save_csv(filename, data):

--- a/check_mi.py
+++ b/check_mi.py
@@ -393,17 +393,11 @@ def main():
     pre_count = 0
 
     for root, sub_dirs, files in os.walk(check_path):
-        
-        media_files = []
         for filename in files:
             if is_target_file(filename):
-                media_files.append(filename)
-
-        pre_count += len(media_files)
-
-        for filename in media_files:
-            full_filename = os.path.join(root, filename)
-            task_queue.put(full_filename)
+                pre_count += 1
+                full_filename = os.path.join(root, filename)
+                task_queue.put(full_filename)
 
         if not CONFIG.is_recurse:
             break  # we only check the root folder

--- a/check_mi.py
+++ b/check_mi.py
@@ -245,7 +245,13 @@ def ffmpeg_check(filename, error_detect='default', threads=0):
         stream = ffmpeg.input(filename, **{'err_detect': custom, 'threads': threads})
 
     stream = stream.output('pipe:', format="null")
-    stream.run(capture_stdout=True, capture_stderr=True, input='')
+    try:
+        stream.run(capture_stdout=True, capture_stderr=True, input='')
+    except ffmpeg.Error as e:
+        raise Exception(
+            'ffmpeg error: ' +
+            e.stderr.rstrip().rsplit(b"\n", 1)[-1].decode("utf-8")
+        )
 
 
 def save_csv(filename, data):

--- a/check_mi.py
+++ b/check_mi.py
@@ -423,7 +423,7 @@ def main():
             # visualization logs and stats
             timed_logger.print_log(count, count_bad, total_file_size)
     except Empty as e:
-        print("Waiting other results for too much time, perhaps you have to raise the timeout", e.message)
+        print("Waiting other results for too much time, perhaps you have to raise the timeout", str(e))
     print("\n**Task completed**\n")
     timed_logger.print_log(count, count_bad, total_file_size, force=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-ffmpeg-python==0.1.17
-future==0.17.1
-Pillow-SIMD==5.3.0.post0
-PyPDF2==1.26.0
-Wand==0.4.5
+ffmpeg-python==0.2.0
+Pillow-SIMD==9.0.0.post1
+PyPDF2==3.0.1
+Wand==0.6.13


### PR DESCRIPTION
This is dependent on PR #19. Really this PR is just the last 2 commits.

The `xerror` option adds the `-xerror` option to ffmpeg which causes it to exit early on any corrupt frames. The `stderr` option causes the `ffmpeg_check` call to fail if there is any error level log messages.

This was implemented as psuedo options to err_detect instead of a new option to have all ffmpeg error handling options go through one option. Also, even though ffmpeg's `-err_detect` option has no effect for me, even on the video files with corruption that I've tried, I've left this capability as it might be working for others.